### PR TITLE
Initial build-and-publish GH Actions workflow [#27]

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,96 @@
+# This file handles lints the game, builds it, and uploads to Itch when changes are pushed.
+# Please do not modify this file unless you have very good reason to do so, as it will likely break the game for everyone else.
+
+name: Build and Publish
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore: # do not build for game-irrelvant changes
+      - ".**"
+      - "LICENSE"
+      - "ACKNOWLEDGEMENTS"
+      - "**.md"
+
+jobs:
+  # Runs the "gdformat" auto-formatter
+  format_code:
+    permissions:
+      contents: write
+
+    runs-on: ubuntu-latest
+
+    # Since auto-formatting creates a commit, we need to make sure we don't create an infinite loop
+    if: "!contains(github.event.head_commit.message, 'Auto-Format GDScript')"
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.x
+
+      - run: pip3 install 'gdtoolkit==3.*'
+
+      - run: gdformat **/*.gd
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Auto-Format GDScript
+          commit_user_name: Little Waluigi
+          file_pattern: "**/*.gd"
+
+  build_game:
+    name: Build Game
+    # Besides skipping autoformat commits, we can manually apply a label to skip releasing
+    if: ${{ github.event.label.name != 'skip release' && !contains(github.event.head_commit.message, 'Auto-Format GDScript') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout latest code
+        uses: actions/checkout@v3
+
+      - name: update credits
+        uses: actions/github-script@v3
+        with:
+          script: |
+            const path = require('path');
+            const script = require(path.resolve('.github/workflows/update-credits.js'));
+            await script(github, context)
+
+      - name: Add credits.txt to build artifacts list
+        uses: actions/upload-artifact@v3
+        with:
+          name: credits
+          path: credits.txt
+
+      - name: export with Godot Engine and release on GitHub
+        uses: firebelley/godot-export@v5.0.0
+        with:
+          godot_executable_download_url: https://downloads.tuxfamily.org/godotengine/3.5.2/Godot_v3.5.2-stable_linux_headless.64.zip
+          godot_export_templates_download_url: https://downloads.tuxfamily.org/godotengine/3.5.2/Godot_v3.5.2-stable_export_templates.tpz
+          relative_project_path: .
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  upload_game:
+    runs-on: ubuntu-latest
+    name: Publish Game
+    needs: [build_game]
+    steps:
+      - name: download latest HTML5 build
+        id: download-html
+        uses: dsaltares/fetch-gh-release-asset@master
+        with:
+          version: "latest"
+          file: HTML5.zip
+          token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: deploy to itch.io
+        uses: josephbmanley/butler-publish-itchio-action@master
+        env:
+          BUTLER_CREDENTIALS: ${{ secrets.ITCH_API_KEY }}
+          CHANNEL: html
+          ITCH_GAME: little-warioware
+          ITCH_USER: new-cylandia
+          PACKAGE: HTML5.zip
+          VERSION: ${{ steps.download-html.outputs.version }}

--- a/.github/workflows/update-credits.js
+++ b/.github/workflows/update-credits.js
@@ -1,0 +1,24 @@
+module.exports = async (github, context) => {
+  var fs = require('fs');
+
+  var names = '';
+
+  for (let page = 1; ; page += 1) {
+    var response = await github.repos.listContributors({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      per_page: 100,
+      page: page
+    });
+    if (response.data.length == 0) {
+      break;
+    }
+    for (const contributor of response.data) {
+      if (contributor.type == 'User') {
+        names += contributor.login + '\n';
+      }
+    }
+  }
+
+  fs.writeFileSync('credits.txt', names);
+}


### PR DESCRIPTION
This copies (and ever-so-slightly updates) our build-and-publish workflow from A Little Game Called Mario:

1. Auto-format GDScript via the `gdformat` tool, making a bot git commits if necessary
2. Creates a credits.txt file containing a list of GitHub usernames based on GH contributor API in the root directory of the project, ready for consumption by Godot
3. Builds the game and uploads it as an artifact
4. Deploys the build to Itch.io

On merging this, steps 1-3 should work (although we are not yet consuming the credits.txt file). Step 4 requires us to generate a butler API key (instructions here: https://itch.io/docs/butler/login.html#running-butler-from-ci-builds-travis-ci-gitlab-ci-etc). This is gated on @iznaut either generating a key or giving me access to the `new-cylandia` itch account.

The two pieces that exist in little-mario that haven't been ported:
1. Deploy previews. I'm going to attempt building these using Azure Static Web Apps instead of Netlify
2. The various grab bag of checks we had in place (validating narrative JSON, collision mask layer checks). My instinct is to add these sorts of checks ad-hoc as issues arise.

I think this should be good to merge, unless anyone has any thoughts.

My one open question: this hardcodes us as using Godot 3.5.2. I think this is correct, but isn't documented anywhere. I'd love someone else who's been working on this to confirm that, and if so we should probably add it to the README and add the same sort of popup (#29)

